### PR TITLE
Force org.json dependency to 2014 version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,12 @@ configurations {
     compile.extendsFrom shade
 }
 
+configurations.all {
+    resolutionStrategy{
+        force 'org.json:json:20140107'
+    }
+}
+
 dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.


### PR DESCRIPTION
The version of `org.json:json` depended on by the Java socket.io client is pretty outdated (from 2009!) and conflicts with several other mods (notably Vivecraft). This PR forces the library dependency to version 20140107, which resolves the conflict.

This patch compiles & seems to function well with Vivecraft installed from initial testing with Streamlabs.