### PR TITLE
Extract streamelements raid count

### DIFF
--- a/src/main/java/net/programmer/igoodie/twitchspawn/tslanguage/event/builder/EventBuilder.java
+++ b/src/main/java/net/programmer/igoodie/twitchspawn/tslanguage/event/builder/EventBuilder.java
@@ -59,7 +59,7 @@ public abstract class EventBuilder {
         eventArguments.donationAmount = JSONUtils.extractNumberFrom(data, "amount", 0.0).doubleValue();
         eventArguments.donationCurrency = JSONUtils.extractFrom(data, "currency", String.class, null);
         eventArguments.subscriptionMonths = JSONUtils.extractNumberFrom(data, "amount", 0).intValue();
-//        eventArguments.raiderCount = JSONUtils.extractNumberFrom(message, "raiders", 0).intValue(); // Raids aren't supported (?)
+        eventArguments.raiderCount = JSONUtils.extractNumberFrom(data, "amount", 0).intValue(); // Raids aren't supported (?)
         eventArguments.viewerCount = JSONUtils.extractNumberFrom(data, "amount ", 0).intValue();
         eventArguments.subscriptionTier = extractTier(data, "tier");
         // TODO: add gifted


### PR DESCRIPTION
It looks like StreamElements is passing the Twitch Raid count in the amount field:

```
[20:37:59] [EventThread/INFO]: Received StreamElements packet (raid, twitch) -> {
  "amount":2,
  "quantity":0,
  "providerId":"615504769",
  "displayName":"gpduckbot",
  "avatar":"https://cdn.streamelements.com/static/default-avatar.png",
  "username":"gpduckbot"
}
```

This should allow support for StreamElements Twitch Raid events now I believe?