### PR TITLE
Fix 5 streamer connection limit

### DIFF
--- a/src/main/java/net/programmer/igoodie/twitchspawn/tracer/TraceManager.java
+++ b/src/main/java/net/programmer/igoodie/twitchspawn/tracer/TraceManager.java
@@ -41,6 +41,18 @@ public class TraceManager {
 
         running = true;
 
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.setMaxRequests(100);
+        dispatcher.setMaxRequestsPerHost(100);
+
+        OkHttpClient okHttpClient = new OkHttpClient.Builder()
+                .dispatcher(dispatcher)
+                .readTimeout(0, TimeUnit.MILLISECONDS)
+                .build();
+
+        IO.setDefaultOkHttpWebSocketFactory(okHttpClient);
+        IO.setDefaultOkHttpCallFactory(okHttpClient);
+
         // Start Websocket tracers
         this.webSocketTracers.add(new TwitchPubSubTracer(this)); // TODO: Extract to a worker, not master
         this.webSocketTracers.add(new TwitchChatTracer(this)); // TODO: Extract to a worker, not master

--- a/src/main/java/net/programmer/igoodie/twitchspawn/tracer/WebSocketTracer.java
+++ b/src/main/java/net/programmer/igoodie/twitchspawn/tracer/WebSocketTracer.java
@@ -54,7 +54,12 @@ public abstract class WebSocketTracer {
     }
 
     protected WebSocket startClient(WebSocketListener listener) {
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.setMaxRequests(100);
+        dispatcher.setMaxRequestsPerHost(100);
+
         OkHttpClient client = new OkHttpClient.Builder()
+                .dispatcher(dispatcher)
                 .readTimeout(0, TimeUnit.MILLISECONDS)
                 .build();
 


### PR DESCRIPTION
SocketIO library (https://github.com/socketio/socket.io-client-java) has a default connection limit of 5, this change increases that limit to 100